### PR TITLE
Add backlog module with text summarizer

### DIFF
--- a/modules/backlog.py
+++ b/modules/backlog.py
@@ -65,5 +65,28 @@ def update_backlog(jenni, input):
 update_backlog.rule = r".*"
 update_backlog.priority = "medium"
 
+def summary(jenni, input):
+    """Parses the backlog of the current channel and creates a summary"""
+    channel = input.sender
+    nick = input.nick
+    max_lines = input.group(2)
+
+    # Backlog is only logged for channels
+    if not channel.startswith("#"):
+        return
+
+    if max_lines:
+        backlog = read_backlog(jenni, channel, max_lines)
+    else:
+        backlog = read_backlog(jenni, channel)
+    backlog_str = "\n".join(backlog)
+
+    jenni.say(backlog_str)
+    pass
+
+summary.commands = ['summary']
+summary.example = '.summary LINES'
+summary.priority = "high"
+
 if __name__ == "__main__":
     print __doc__.strip()

--- a/modules/backlog.py
+++ b/modules/backlog.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""
+backlog.py - jenni backlog utilities
+"""
+
+import os, re
+import threading
+
+def setup(self):
+    fn = self.nick + "-" + self.config.host + ".backlog.db"
+    self.backlog_filename = os.path.join(os.path.expanduser("~/.jenni"), fn)
+    if not os.path.exists(self.backlog_filename):
+        try: f = open(self.backlog_filename, "w")
+        except OSError: pass
+        else:
+            f.write("")
+            f.close()
+    self.backlog_lock = threading.Lock()
+
+def update_backlog(jenni, input):
+    """Write every received line to a backlog file"""
+    channel = input.sender
+    nick = input.nick
+    line = input.group()
+
+    # Rules for lines that should be excluded
+    if not channel.startswith("#"):
+        return
+    elif line.startswith("."):
+        return
+    elif line.startswith("s/"):
+        return
+
+    jenni.backlog_lock.acquire()
+    try:
+        backlog_file = open(jenni.backlog_filename, "a")
+        backlog_file.write("{},{},{}\n".format(channel, nick, line))
+        backlog_file.close()
+        #TODO: Check backlog size and clear oldest entries if needed
+    finally:
+        jenni.backlog_lock.release()
+update_backlog.rule = r".*"
+update_backlog.priority = "medium"
+
+if __name__ == "__main__":
+    print __doc__.strip()

--- a/modules/backlog.py
+++ b/modules/backlog.py
@@ -17,6 +17,29 @@ def setup(self):
             f.close()
     self.backlog_lock = threading.Lock()
 
+def read_backlog(jenni, filter_channel=None, max_lines=100):
+    """Read backlog file and return all entries from a specific channel"""
+    channel_log = list()
+
+    jenni.backlog_lock.acquire()
+    try:
+        backlog_file = open(jenni.backlog_filename, "r")
+        backlog_lines = backlog_file.readlines()
+
+        for line in backlog_lines:
+            elements = line.split(",", 2)
+            if len(elements) < 3: continue
+            (channel, nick, log) = elements
+
+            if filter_channel and channel != filter_channel:
+                continue
+            channel_log.append(log)
+
+        backlog_file.close()
+    finally:
+        jenni.backlog_lock.release()
+    return channel_log[-max_lines:]
+
 def update_backlog(jenni, input):
     """Write every received line to a backlog file"""
     channel = input.sender


### PR DESCRIPTION
Add a new module to persistently store the chat history in a file for later text analysis.
Use the newly generated history file to provide a summary/tldr feature by using the [sumy](https://github.com/miso-belica/sumy) python library.
